### PR TITLE
Make module Windows PowerShell 5.1 compatible

### DIFF
--- a/SelfSignedCertificate/SelfSignedCertificate.psd1
+++ b/SelfSignedCertificate/SelfSignedCertificate.psd1
@@ -11,10 +11,10 @@
 RootModule = 'SelfSignedCertificate.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.2'
+ModuleVersion = '0.0.3'
 
 # Supported PSEditions
-CompatiblePSEditions = 'Core'
+CompatiblePSEditions = 'Core', 'Desktop'
 
 # ID used to uniquely identify this module
 GUID = '634218b8-3334-4f10-ba89-2b79b0fd9fc4'
@@ -32,7 +32,7 @@ Copyright = '© Robert Holt'
 Description = 'Provides functionality for creating, processing and manipulating self-signed certificates in PowerShell'
 
 # Minimum version of the PowerShell engine required by this module
-PowerShellVersion = '6.1'
+PowerShellVersion = '5.1'
 
 # Name of the PowerShell host required by this module
 # PowerShellHostName = ''

--- a/Tests/SelfSignedCertificate.Tests.ps1
+++ b/Tests/SelfSignedCertificate.Tests.ps1
@@ -12,7 +12,7 @@ function Get-MillisecondTruncatedTime
 
 Describe "Generates a simple self signed certificate" {
     BeforeAll {
-        Import-Module (Join-Path $PSScriptRoot '..' 'SelfSignedCertificate')
+        Import-Module ([System.IO.Path]::Combine($PSScriptRoot, '..', 'SelfSignedCertificate'))
 
         $certSubject = @{
             CommonName = 'donotuse.example.info'
@@ -60,8 +60,6 @@ Describe "Generates a simple self signed certificate" {
         $sha256RsaOid = "1.2.840.113549.1.1.11"
         $loadedCert.SignatureAlgorithm.Value | Should -Be $sha256RsaOid
         $loadedCert.PublicKey.Key.KeySize | Should -Be $certParameters.KeyLength
-        $loadedCert.PublicKey.Key.KeyExchangeAlgorithm | Should -Be 'RSA'
-        $loadedCert.PublicKey.Key.SignatureAlgorithm | Should -Be 'RSA'
     }
 
     It "Has the expected start date" {


### PR DESCRIPTION
Also removes part of a test that we don't really want to guarantee -- it fails on Windows PowerShell but doesn't reflect a breakage in the module.